### PR TITLE
Feature/check instagram app : 인스타그램 설치 유무 확인 후 설치 다이얼로그 표시 기능 추가

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -27,6 +27,8 @@ PODS:
     - Flutter
   - social_share (0.0.1):
     - Flutter
+  - url_launcher_ios (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - camera_avfoundation (from `.symlinks/plugins/camera_avfoundation/ios`)
@@ -40,6 +42,7 @@ DEPENDENCIES:
   - permission_handler (from `.symlinks/plugins/permission_handler/ios`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - social_share (from `.symlinks/plugins/social_share/ios`)
+  - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 SPEC REPOS:
   trunk:
@@ -70,6 +73,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/share_plus/ios"
   social_share:
     :path: ".symlinks/plugins/social_share/ios"
+  url_launcher_ios:
+    :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
   BSGridCollectionViewLayout: 333dcb457a5a3bdd9212607ab5756553dcfe06cb
@@ -86,6 +91,7 @@ SPEC CHECKSUMS:
   permission_handler: ccb20a9fad0ee9b1314a52b70b76b473c5f8dab0
   share_plus: 056a1e8ac890df3e33cb503afffaf1e9b4fbae68
   social_share: 702a5e3842addd22db515aa9e1e00a4b80a0296d
+  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
 
 PODFILE CHECKSUM: f393a3e970b6bcad3ccd24fdc079653b90c459b1
 

--- a/lib/screens/display_picture_screen.dart
+++ b/lib/screens/display_picture_screen.dart
@@ -138,9 +138,9 @@ class _DisplayPictureScreenState extends State<DisplayPictureScreen> {
       context: context,
       builder: (BuildContext context) {
         return AlertDialog(
-          title: Text('Instagram not installed'),
+          title: Text('Instagram Not Installed'),
           content: Text(
-              'Would you like to install Instagram to share to your story'),
+              'Install Instagram to share your story?'),
           actions: <Widget>[
             TextButton(
               child: Text('Cancel'),

--- a/lib/screens/display_picture_screen.dart
+++ b/lib/screens/display_picture_screen.dart
@@ -12,6 +12,8 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:image/image.dart' as img;
 import 'package:flutter/material.dart' hide Image;
 import 'package:flutter/cupertino.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:url_launcher/url_launcher_string.dart';
 
 class DisplayPictureScreen extends StatefulWidget {
   final img.Image mergedFourImage;
@@ -114,6 +116,48 @@ class _DisplayPictureScreenState extends State<DisplayPictureScreen> {
     } else {
       print('Permission denied');
     }
+  }
+
+  //인스타그램 앱 유무를 확인하고 인스타그램 스토리에 이미지를 공유하는 메서드
+  Future<void> checkAndShareImageToInstagramStory() async {
+    //인스타그램 URL 스킴
+    const instagramUrl = 'instagram://app';
+
+    //인스타그램이 설치되어 있는지 확인
+    if (await canLaunchUrlString(instagramUrl)) {
+      await shareImageToInstagramStory();
+    } else {
+      print('Instagram not installed');
+      showInstallInstagramDialog();
+    }
+  }
+
+  //인스타그램 설치 다이얼로그를 표시하는 메서드
+  void showInstallInstagramDialog() {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: Text('Instagram not installed'),
+          content: Text(
+              'Would you like to install Instagram to share to your story'),
+          actions: <Widget>[
+            TextButton(
+              child: Text('Cancel'),
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+            TextButton(
+              child: Text('Install'),
+              onPressed: () {
+                launch('https://apps.apple.com/us/app/instagram/id389801252');
+              },
+            ),
+          ],
+        );
+      },
+    );
   }
 
   Future<void> shareImageToInstagramStory() async {
@@ -293,7 +337,7 @@ class _DisplayPictureScreenState extends State<DisplayPictureScreen> {
             ),
             child: FloatingActionButton(
               backgroundColor: Colors.transparent,
-              onPressed: shareImageToInstagramStory,
+              onPressed: checkAndShareImageToInstagramStory,
               child: Image.asset(
                 'assets/instagram_icon_bw.png',
                 width: 28,

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,9 +8,11 @@ import Foundation
 import file_selector_macos
 import path_provider_foundation
 import share_plus
+import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -741,6 +741,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.2"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: "21b704ce5fa560ea9f3b525b43601c678728ba46725bab9b01187b4831377ed3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.0"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: f0c73347dfcfa5b3db8bc06e1502668265d39c08f310c29bff4e28eea9699f79
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.9"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: e43b677296fadce447e987a2f519dcf5f6d1e527dc35d01ffab4fff5b8a7063e
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.1"
   url_launcher_linux:
     dependency: transitive
     description:
@@ -749,6 +773,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "9a1a42d5d2d95400c795b2914c36fdcb525870c752569438e4ebb09a2b5d90de"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.0"
   url_launcher_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,7 @@ dependencies:
   share_plus: ^6.0.1
   social_share: ^2.0.5
   flutter_native_splash: ^2.0.6+1
+  url_launcher: ^6.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
display_picture_screen.dart 파일에 2개의 메서드를 추가하였습니다!

1. checkAndShareImageToInstagramStory()
  - 사용자가 인스타그램 버튼 클릭 시 URL 스킴으로 인스타그램 앱 설치를 확인하는 메서드. 
  - 기기에 설치되어 있다면 기존의 shareImageToInstagramStory() 메서드를 호출함
  - 기기에 설치되지 않았다면 showInstallInstagramDialog() 메서드를 호출함

2. showInstallInstagramDialog()
- 사용자에게 인스타그램 설치를 유도하는 다이얼로그 표시 
<img src="https://github.com/user-attachments/assets/b8018e72-a2f2-4918-8397-e97a18ccbe08" width="300" height="600"/>

=> 위 이미지에서 content만 'Install Instagram to share your story?' 로 바꿈.