### PR TITLE
Fix/overlay failed : 오버레이 실패 시 대응 방법 수정

### DIFF
--- a/lib/screens/remove_bg_screen.dart
+++ b/lib/screens/remove_bg_screen.dart
@@ -55,7 +55,8 @@ class _RemoveBackGroundScreenState extends State<RemoveBackGroundScreen> {
     for (int i = 0; i < uploadedImages.length; i++) {
       try {
         LocalRembgResultModel localRembgResultModel =
-            await LocalRembg.removeBackground(imagePath: uploadedImages[i].path);
+            await LocalRembg.removeBackground(
+                imagePath: uploadedImages[i].path);
         if (localRembgResultModel.status == 1) {
           Uint8List imageBytes =
               Uint8List.fromList(localRembgResultModel.imageBytes!);
@@ -67,12 +68,12 @@ class _RemoveBackGroundScreenState extends State<RemoveBackGroundScreen> {
               'Background removal failed: ${localRembgResultModel.errorMessage}');
         }
       } catch (e) {
-        print('Error processing ${i+1}th image: $e');
+        print('Error processing ${i + 1}th image: $e');
         // Show alert and wait for user response
         await showDialog<void>(
             context: context,
             builder: (BuildContext context) {
-              return _showAlertAndChooseWays(context, i+1);
+              return _showAlertAndChooseWays(context, i + 1);
             });
       }
     }
@@ -138,37 +139,65 @@ class _RemoveBackGroundScreenState extends State<RemoveBackGroundScreen> {
   }
 
   Widget _showAlertAndChooseWays(BuildContext context, int index) {
+    final ButtonStyle btnStyle = ElevatedButton.styleFrom(
+      textStyle: const TextStyle(fontSize: 14),
+      fixedSize: Size(300, 50),
+    );
     // 한 이미지에서 배경 제거 실패 시
-    return CupertinoAlertDialog(
-      title: Text('Background removal failed'),
-      content: Text(
-          'This process failed for the ${index}th photo.\nPlease choose an option below.'),
-      actions: <Widget>[
-        TextButton(
+    return Center(
+      child: AlertDialog(
+        title: Padding(
+          padding: const EdgeInsets.only(bottom: 10),
           child: Text(
-            'Use Only Successful Photos in a Random Order',
-            style: TextStyle(color: Colors.blue),
+            'Background removal failed',
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.w500,
+            ),
           ),
-          onPressed: () {
-            // 현재 다이얼로그를 닫고 이전 과정을 이어서 실행
-            Navigator.of(context).pop();
-          },
         ),
-        TextButton(
+        content: Padding(
+          padding: EdgeInsets.only(bottom: 20),
           child: Text(
-            'Re-upload All Photos',
-            style: TextStyle(color: Colors.blue),
+            'This process failed for the ${index}th photo.\nPlease choose an option below.',
+            textAlign: TextAlign.center,
           ),
-          onPressed: () {
-            // 사용자가 전체 사진을 재업로드할 수 있도록 처리
-            setState(() {
-              isLoading = false;
-              uploadedImages.clear();
-            });
-            Navigator.of(context).pop();
-          },
         ),
-      ],
+        actions: <Widget>[
+          Center(
+            child: ElevatedButton(
+              style: btnStyle,
+              child: Text(
+                'Use Only Successful Photos \nin a Random Order',
+                textAlign: TextAlign.center,
+              ),
+              onPressed: () {
+                // 현재 다이얼로그를 닫고 이전 과정을 이어서 실행
+                Navigator.of(context).pop();
+              },
+            ),
+          ),
+          const SizedBox(height: 10),
+          Center(
+            child: ElevatedButton(
+              style: btnStyle,
+              child: Text(
+                'Re-upload All Photos',
+                textAlign: TextAlign.center,
+              ),
+              onPressed: () {
+                // 사용자가 전체 사진을 재업로드할 수 있도록 처리
+                setState(() {
+                  isLoading = false;
+                  uploadedImages.clear();
+                });
+                Navigator.of(context).pop();
+              },
+            ),
+          ),
+        ],
+      ),
     );
   }
 

--- a/lib/screens/remove_bg_screen.dart
+++ b/lib/screens/remove_bg_screen.dart
@@ -69,12 +69,22 @@ class _RemoveBackGroundScreenState extends State<RemoveBackGroundScreen> {
         }
       } catch (e) {
         print('Error processing ${i + 1}th image: $e');
-        // Show alert and wait for user response
-        await showDialog<void>(
-            context: context,
-            builder: (BuildContext context) {
-              return _showAlertAndChooseWays(context, i + 1);
-            });
+        // 배경 제거 실패 시 사용자의 선택에 따라 다음 단계 진행
+        bool? shouldReupload = await showDialog<bool>( 
+          context: context,
+          builder: (BuildContext context) {
+            return _showAlertAndChooseWays(context, i + 1);
+          },
+        );
+        // 사용자가 전체 사진을 재업로드하기로 결정했을 때
+        // 또는 사용자가 dialog에서 선택하지 않았을 때
+        if (shouldReupload == null || shouldReupload) {
+          setState(() {
+            isLoading = false;
+            uploadedImages.clear();
+          });
+          return;
+        }
       }
     }
 
@@ -174,7 +184,7 @@ class _RemoveBackGroundScreenState extends State<RemoveBackGroundScreen> {
               ),
               onPressed: () {
                 // 현재 다이얼로그를 닫고 이전 과정을 이어서 실행
-                Navigator.of(context).pop();
+                Navigator.of(context).pop(false);
               },
             ),
           ),
@@ -188,11 +198,7 @@ class _RemoveBackGroundScreenState extends State<RemoveBackGroundScreen> {
               ),
               onPressed: () {
                 // 사용자가 전체 사진을 재업로드할 수 있도록 처리
-                setState(() {
-                  isLoading = false;
-                  uploadedImages.clear();
-                });
-                Navigator.of(context).pop();
+                Navigator.of(context).pop(true);
               },
             ),
           ),


### PR DESCRIPTION
오버레이 탭에서 배경 이미지 제거 실패 시, 실패 안내와 함께 다음의 2가지 방법을 제안하는 dialog를 띄우도록 수정하였습니다.
1. 성공한 사진만 반복해서 사용
2. 4개의 사진을 재업로드
<br>
코드에서는 다음 2개의 메서드가 추가되었습니다.
<br>
<br>

1. `showAlertAndChooseWays()` : 배경 제거 실패 시 사용자에게 2가지 방법을 제시하는 dialog를 리턴하는 메서드
2. `useSuccessfulPhotos()`: 사용자가 "성공한 사진만 반복해서 사용"을 선택하여 processedImageUrls 배열의 요소가 부족할 경우, processedImageUrls 배열에 존재하는 성공한 사진들을 랜덤하게 골라 부족한 요소만큼 추가
<br>

결과는 다음과 같습니다.

- 오버레이 이미지 생성 실패 시, 몇번째 사진이 실패했는지 `dialog`로 안내
<img src="https://github.com/user-attachments/assets/ac9aeb19-c69e-456e-935e-4de2558b19e4" width="300" height="600"/>
<br>

- `Use Only Successful photos in a Random Order` 선택 시

  - 이전에 성공한 오버레이 이미지 랜덤으로 추가
  - 이전에 성공한 오버레이 이미지가 없을 경우, 이미지 업로드 화면으로 돌아감

<img src="https://github.com/user-attachments/assets/2582026c-f3f9-47e9-9c96-6e56e0ca5a42" width="350" height="600"/>
<br>

- `Re-upload All Photos` 선택하거나, dialog 바깥을 누를 경우(선택하지 않을 경우)
  - uploadImages 배열을 초기화하고 이미지 업로드 화면을 재랜더링

